### PR TITLE
Test 2 – CREATE INDEX

### DIFF
--- a/deploy/pgbench-accounts-index-bid.sql
+++ b/deploy/pgbench-accounts-index-bid.sql
@@ -1,4 +1,4 @@
 -- Deploy green-zone:pgbench-accounts-index-bid to pg
 
 
-create index concurrently bid_idx on pgbench_accounts(bid);
+create index bid_idx on pgbench_accounts(bid);

--- a/deploy/pgbench-accounts-index-bid.sql
+++ b/deploy/pgbench-accounts-index-bid.sql
@@ -1,4 +1,4 @@
 -- Deploy green-zone:pgbench-accounts-index-bid to pg
 
 
-create index concurrently bid_idx on pgbench_accounts(bid);
+create index /*concurrently*/ bid_idx on pgbench_accounts(bid);

--- a/deploy/pgbench-accounts-index-bid.sql
+++ b/deploy/pgbench-accounts-index-bid.sql
@@ -1,3 +1,3 @@
 -- Deploy green-zone:pgbench-accounts-index-bid to pg
 
-create index /**concurrently**/ bid_idx on pgbench_accounts(bid);
+create index concurrently bid_idx on pgbench_accounts(bid);

--- a/deploy/pgbench-accounts-index-bid.sql
+++ b/deploy/pgbench-accounts-index-bid.sql
@@ -1,4 +1,4 @@
 -- Deploy green-zone:pgbench-accounts-index-bid to pg
 
 
-create index /**concurrently**/ bid_idx on pgbench_accounts(bid);
+create index concurrently bid_idx on pgbench_accounts(bid);

--- a/deploy/pgbench-accounts-index-bid.sql
+++ b/deploy/pgbench-accounts-index-bid.sql
@@ -1,4 +1,4 @@
 -- Deploy green-zone:pgbench-accounts-index-bid to pg
 
 
-create index concurrently bid_idx on pgbench_accounts(bid);
+create index /***concurrently***/ bid_idx on pgbench_accounts(bid);

--- a/deploy/pgbench-accounts-index-bid.sql
+++ b/deploy/pgbench-accounts-index-bid.sql
@@ -1,4 +1,4 @@
 -- Deploy green-zone:pgbench-accounts-index-bid to pg
 
 
-create index concurrently bid_idx on pgbench_accounts(bid);
+create index  bid_idx on pgbench_accounts(bid);

--- a/deploy/pgbench-accounts-index-bid.sql
+++ b/deploy/pgbench-accounts-index-bid.sql
@@ -1,4 +1,4 @@
 -- Deploy green-zone:pgbench-accounts-index-bid to pg
 
 
-create index bid_idx on pgbench_accounts(bid);
+create index concurrently bid_idx on pgbench_accounts(bid);

--- a/deploy/pgbench-accounts-index-bid.sql
+++ b/deploy/pgbench-accounts-index-bid.sql
@@ -1,4 +1,4 @@
 -- Deploy green-zone:pgbench-accounts-index-bid to pg
 
 
-create index concurrently bid_idx on pgbench_accounts(bid);
+create index /**concurrently**/ bid_idx on pgbench_accounts(bid);

--- a/deploy/pgbench-accounts-index-bid.sql
+++ b/deploy/pgbench-accounts-index-bid.sql
@@ -1,4 +1,4 @@
 -- Deploy green-zone:pgbench-accounts-index-bid to pg
 
 
-create index /***concurrently***/ bid_idx on pgbench_accounts(bid);
+create index concurrently bid_idx on pgbench_accounts(bid);

--- a/deploy/pgbench-accounts-index-bid.sql
+++ b/deploy/pgbench-accounts-index-bid.sql
@@ -1,4 +1,4 @@
 -- Deploy green-zone:pgbench-accounts-index-bid to pg
 
 
-create index  bid_idx on pgbench_accounts(bid);
+create index concurrently bid_idx on pgbench_accounts(bid);

--- a/deploy/pgbench-accounts-index-bid.sql
+++ b/deploy/pgbench-accounts-index-bid.sql
@@ -1,4 +1,4 @@
 -- Deploy green-zone:pgbench-accounts-index-bid to pg
 
 
-create index /*concurrently*/ bid_idx on pgbench_accounts(bid);
+create index concurrently bid_idx on pgbench_accounts(bid);

--- a/deploy/pgbench-accounts-index-bid.sql
+++ b/deploy/pgbench-accounts-index-bid.sql
@@ -1,4 +1,4 @@
 -- Deploy green-zone:pgbench-accounts-index-bid to pg
 
 
-create index /*** concurrently ***/ bid_idx on pgbench_accounts(bid);
+create index concurrently bid_idx on pgbench_accounts(bid);

--- a/deploy/pgbench-accounts-index-bid.sql
+++ b/deploy/pgbench-accounts-index-bid.sql
@@ -1,3 +1,3 @@
 -- Deploy green-zone:pgbench-accounts-index-bid to pg
 
-create index concurrently bid_idx on pgbench_accounts(bid);
+create index /**concurrently**/ bid_idx on pgbench_accounts(bid);

--- a/deploy/pgbench-accounts-index-bid.sql
+++ b/deploy/pgbench-accounts-index-bid.sql
@@ -1,3 +1,4 @@
 -- Deploy green-zone:pgbench-accounts-index-bid to pg
 
-create index /**concurrently**/ bid_idx on pgbench_accounts(bid);
+
+create index /*** concurrently ***/ bid_idx on pgbench_accounts(bid);


### PR DESCRIPTION
Check out Commits and see how Database Lab's DB Migration Checker detects dangerous DB migrations such as `CREATE INDEX` (without `CONCURRENTLY`). Notice CI/CD statues – click on ❌  and ✔️ icons for each commit and explore the CI job logs.

The DB size in these tests was 37 GiB, providing new thin clones took ~1s every time.